### PR TITLE
Fix MongoDB Boolean constant error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 case ENV['DATABASE_ADAPTER']
 when 'mongoid' then
   gem 'kaminari-mongoid'
-  gem 'mongoid'
+  gem 'mongoid', ENV['MONGOID_VERSION'] || '~> 7.3.0'
   gem 'mongoid-scroll'
 when 'activerecord' then
   gem 'activerecord', '~> 5.0.0'

--- a/lib/slack-ruby-bot-server-stripe/models/mongoid.rb
+++ b/lib/slack-ruby-bot-server-stripe/models/mongoid.rb
@@ -11,7 +11,7 @@ module SlackRubyBotServer
 
         included do
           field :stripe_customer_id, type: String
-          field :subscribed, type: Boolean, default: false
+          field :subscribed, type: ::Mongoid::Boolean, default: false
           field :subscribed_at, type: DateTime
           field :subscription_expired_at, type: DateTime
           field :trial_informed_at, type: DateTime

--- a/lib/slack-ruby-bot-server/api/presenters/team_presenter.rb
+++ b/lib/slack-ruby-bot-server/api/presenters/team_presenter.rb
@@ -4,7 +4,7 @@ module SlackRubyBotServer
   module Api
     module Presenters
       module TeamPresenter
-        property :subscribed, type: Boolean, desc: 'Team is a paid subscriber.'
+        property :subscribed, type: ::Grape::API::Boolean, desc: 'Team is a paid subscriber.'
         property :subscribed_at, type: DateTime, desc: 'Date/time when a subscription was purchased.'
       end
     end


### PR DESCRIPTION
This is just copying over most of the PR from https://github.com/slack-ruby/slack-ruby-bot-server/pull/140 in order to fix the `uninitialized constant SlackRubyBotServer::Stripe::Models::Mongoid::Boolean` error with `mongoid` version 7.3.0+.

This does correct that particular test error, but https://github.com/slack-ruby/slack-ruby-bot-server-stripe/issues/9 still remains.

Closes #10